### PR TITLE
global_device_configs_override: Disable always screen on

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -207,6 +207,9 @@
         <item>systemui/use_back_gesture_ml_model=true</item>
         <item>systemui/back_gesture_ml_model_name=backgesture</item>
         <item>systemui/back_gesture_ml_model_threshold=0.8</item>
+        
+	<!-- Disable always screen on -->
+        <item>attention_manager_service/keep_screen_on_enabled=false</item>
 
         <!-- Don't pin camera app to save memory -->
         <item>runtime_native_boot/pin_camera=false</item>


### PR DESCRIPTION
- Some devices are keeping screen on and not turning off. Reported in some pixels, asus and realme

Issue: https://www.reddit.com/r/LineageOS/comments/uw5d8p/screen_timeout_issue_on_pixels_on_android_12/ https://gitlab.com/LineageOS/issues/android/-/issues/4798

Change-Id: I1e2471928b47387f7e40adb81d3457bb58cc2755