### PR TITLE
vendor: Disable display frame rate override

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -137,6 +137,10 @@ PRODUCT_PACKAGES += \
     product_charger_res_images \
     product_charger_res_images_vendor
 
+# Display
+PRODUCT_SYSTEM_EXT_PROPERTIES += \
+    ro.surface_flinger.enable_frame_rate_override=false
+
 # Repainter integration
 PRODUCT_PACKAGES += \
     RepainterServicePriv


### PR DESCRIPTION
This got enabled by default on U, and it causes apps like Chrome and Youtube to set the refresh rate to 30FPS when playing some videos.

Change-Id: I649bf03d550c2b9726c7957d15ed09e455d874ec